### PR TITLE
fix: correct peerMeta assignment in WalletConnect connection

### DIFF
--- a/packages/src/@xpla/wallet-controller/modules/walletconnect/connect.ts
+++ b/packages/src/@xpla/wallet-controller/modules/walletconnect/connect.ts
@@ -118,7 +118,7 @@ export function connect(
 
       sessionSubject.next({
         status: WalletConnectSessionStatus.CONNECTED,
-        peerMeta: payload.params[0],
+        peerMeta: payload.params[0].peerMeta,
         xplaAddress: payload.params[0].accounts[0],
         chainId: payload.params[0].chainId,
       });
@@ -131,7 +131,7 @@ export function connect(
 
       sessionSubject.next({
         status: WalletConnectSessionStatus.CONNECTED,
-        peerMeta: payload.params[0],
+        peerMeta: payload.params[0].peerMeta,
         xplaAddress: payload.params[0].accounts[0],
         chainId: payload.params[0].chainId,
       });


### PR DESCRIPTION
corrects `peerMeta` assignment when connecting WalletConnect.

I found this mismatch while trying to expose `peerMeta.url` through `useConnectedWallet` on my patch.